### PR TITLE
Oppdater sårbar avhengighet

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,7 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
+            <version>42.7.2</version>
         </dependency>
         <dependency>
             <groupId>org.hibernate.validator</groupId>


### PR DESCRIPTION
Ser vi bruker [posgres avhengighet](https://mvnrepository.com/artifact/org.postgresql/postgresql) versjon 42.6.0 som har en sårbarhet. Oppdaterer til 42.7.2.

https://salsa.nav.cloud.nais.io/projects/df4ffe22-b462-4b17-a45b-ac42c6e29299/findings