### PR TITLE
Endrer til å bruke DB_JDBC_URL

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -16,14 +16,12 @@ spring:
   autoconfigure.exclude: org.springframework.boot.autoconfigure.web.servlet.error.ErrorMvcAutoConfiguration
   main.banner-mode: "off"
   datasource:
+    url: ${DB_JDBC_URL}
     hikari:
       maximum-pool-size: 2
       connection-test-query: "select 1"
       max-lifetime: 30000
       minimum-idle: 1
-    url: jdbc:postgresql://${DB_HOST}:${DB_PORT}/familie-baks-infotrygd-feed
-    username: ${DB_USERNAME}
-    password: ${DB_PASSWORD}
   jpa:
     hibernate:
       ddl-auto: none


### PR DESCRIPTION
For å kunne bruke migreringsverktøyet for db-oppgraderingen, så bør man bruke DB_JDBC_URL. Så bytter til å bruke denne. 

Opppdaget da en morsom ting om at DB_JDBC_URL var feil i dev-gcp
` "DB_JDBC_URL": "jdbc:postgres://127.0.0.1:5432/familie-baks-infotrygd-feed?use......"`

Altså `jdbc:postgres` i stedet for `jdbc:postgresql`

For å fikse denne secreten så måtte man gjøre:
https://doc.nais.io/persistence/cloudsql/how-to/reset-database-credentials/
```
k delete secret google-sql-familie-baks-infotrygd-feed
k delete sqluser familie-baks-infotrygd-feed
k patch application familie-baks-infotrygd-feed -p '[{"op": "remove", "path": "/status/synchronizationHash"}]' --type=json
```
