### PR TITLE
Vi prepper opp til oppgradering til psql 17 og må skru av denne for at  migreringsverktøyet skal funke

### DIFF
--- a/.nais/app-prod.yaml
+++ b/.nais/app-prod.yaml
@@ -32,7 +32,7 @@ spec:
         autoBackupHour: 2
         pointInTimeRecovery: false
         diskAutoresize: true
-        highAvailability: true
+        highAvailability: false
         databases:
           - name: familie-baks-infotrygd-feed
             envVarPrefix: DB


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-26161

Vi prepper opp til oppgradering til psql 17 og må skru av denne for at  migreringsverktøyet skal funke